### PR TITLE
Removed hard coded browser package version.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,5 +5,4 @@ description: A set of libraries designed to provide configuration to Dart applic
 homepage: https://github.com/chrisbu/dart_config
 dependencies:
   unittest: any
-  yaml: '>=0.4.2 <0.5.0'
-  browser: '>=0.3.7+6 <0.3.8'
+  yaml: '>=0.4.2'


### PR DESCRIPTION
The package spec was preventing newer versions of the browser package from being pulled into applications which used this package. Things are changing so fast with the bootstrap and other packages it can cause issues for apps trying to use sub-packages that hard code a max revision range.
