### PR TITLE
Close config file after reading.

### DIFF
--- a/lib/loaders/config_loader_filesystem.dart
+++ b/lib/loaders/config_loader_filesystem.dart
@@ -25,8 +25,13 @@ class ConfigFilesystemLoader extends ConfigLoader {
                       (length) {
                         f.read(length).then((List<int> buffer) {
                           var configText = new String.fromCharCodes(buffer);
-                          completer.complete(configText);
-                        }, onError: errorHandler);
+                          f.close().then(
+                              (f) {
+                                completer.complete(configText);
+                              }, 
+                              onError: errorHandler);
+                        },
+                        onError: errorHandler);
                       }, 
                       onError: errorHandler);
                 }, 

--- a/lib/parsers/config_parser_json.dart
+++ b/lib/parsers/config_parser_json.dart
@@ -1,7 +1,7 @@
 library config_parser_json;
 
 import 'dart:async';
-import 'dart:json' as JSON;
+import 'package:json/json.dart' as JSON;
 
 import '../config.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,6 +4,7 @@ author: Chris Buckett <chrisbuckett@gmail.com>
 description: A set of libraries designed to provide configuration to Dart applications. Using dependency injection, the same library API can load config information from the filesystem and httprequest, formatted as JSON or YAML.  Customization with additional providers is also possible by implementing two simple interfaces.
 homepage: https://github.com/chrisbu/dart_config
 dependencies:
+  json: any
   unittest: any
   yaml: '>=0.4.2'
 dev_dependencies:

--- a/test/test_server.dart
+++ b/test/test_server.dart
@@ -10,6 +10,7 @@ main() {
   tests.pathMap[tests.NESTED_CONFIG_JSON] = "configs/testnestedconfig.json";
   tests.pathMap[tests.SIMPLE_CONFIG_YAML] = "configs/testsimpleconfig.yaml";
   tests.pathMap[tests.NESTED_CONFIG_YAML] = "configs/testnestedconfig.yaml";
+  tests.pathMap[tests.TEMP_CONFIG_YAML] = "configs/testtempconfig.yaml";
   tests.loaderImpl = new ConfigFilesystemLoader();
   tests.runTests();
 }


### PR DESCRIPTION
I came across a problem when using config to read temporary config files that are later deleted.  config currently leaves the file open after reading it, preventing the file from later being deleted.
