### PR TITLE
Dart compatibility updates for JSON decoding and Unit test signatures

### DIFF
--- a/lib/parsers/config_parser_json.dart
+++ b/lib/parsers/config_parser_json.dart
@@ -1,7 +1,7 @@
 library config_parser_json;
 
 import 'dart:async';
-import 'dart:json' as JSON;
+import 'dart:convert';
 
 import '../config.dart';
 
@@ -10,7 +10,7 @@ class JsonConfigParser implements ConfigParser {
   Future<Map> parse(String configText) {
     var completer = new Completer<Map>();
     
-    var map = JSON.parse(configText);
+    var map = JSON.decode(configText);
     completer.complete(map);
     
     return completer.future;

--- a/test/tests.dart
+++ b/test/tests.dart
@@ -106,7 +106,7 @@ class MapMatcher implements Matcher {
 
   // JSON parse the item back into a map, and compare the two maps
   // (brute force, innefficient)
-  bool matches(Map item, MatchState matchState) {
+  bool matches(Map item, Map matchState) {
     var result = true;
 
     // try and compare the item and the map
@@ -120,7 +120,7 @@ class MapMatcher implements Matcher {
   }
 
   Description describeMismatch(item, Description mismatchDescription,
-                               MatchState matchState, bool verbose) {
+                               Map matchState, bool verbose) {
     mismatchDescription.add("item: ${item.toString()}");
     return mismatchDescription;
 


### PR DESCRIPTION
Apparently Dart has seen some changes in some core libraries: the JSON library is now merged into dart:convert ( https://groups.google.com/a/dartlang.org/forum/#!msg/misc/GtHctOErzcY/mT92rPaQkQQJ ) and the unit test method signatures now use a Map as the MatchState.
